### PR TITLE
Accept FCM 'Deprecated endpoint' error

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.10.2
+elixir 1.10.3-otp-23

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -180,8 +180,11 @@ defimpl Pigeon.Configurable, for: Pigeon.FCM.Config do
 
   def parse_error(data) do
     case Pigeon.json_library().decode(data) do
+      {:ok, %{"reason" => reason}} ->
+        reason |> Macro.underscore() |> String.to_existing_atom()
+
       {:ok, response} ->
-        response["reason"] |> Macro.underscore() |> String.to_existing_atom()
+        response["error"]
 
       error ->
         "JSON parse failed: #{inspect(error)}, body: #{inspect(data)}"

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -184,7 +184,8 @@ defimpl Pigeon.Configurable, for: Pigeon.FCM.Config do
         reason |> Macro.underscore() |> String.to_existing_atom()
 
       {:ok, response} ->
-        response["error"]
+        Logger.warn("error with no reason #{response["error"]}")
+        :unspecified_reason
 
       error ->
         "JSON parse failed: #{inspect(error)}, body: #{inspect(data)}"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Pigeon.Mixfile do
   use Mix.Project
 
-  @version "1.6.1"
+  @version "1.7.1"
 
   def project do
     [


### PR DESCRIPTION
Handle an error which doesn't have a reason.

This fork is created from the midpoint of the 1.6 branch to avoid picking up an Elixir upgrade from 1.10 to 1.13 and associated dependency updates. I want to keep this simple.